### PR TITLE
Improve error handling for remote data source connections

### DIFF
--- a/R/datasource.R
+++ b/R/datasource.R
@@ -27,7 +27,7 @@ NULL
 #'  available_datasets()
 #' }
 #' ## set to one of those
-#' ds  <- datasource("ghrsst-tif")
+#' try(ds  <- datasource("ghrsst-tif"))
 #' ## access the 'ds@source' slot, files with 'date','source' (GDAL-readable)
 datasource <- S7::new_class(name = "dataset", package = "sooty",
   properties = list(
@@ -54,7 +54,7 @@ datasource <- S7::new_class(name = "dataset", package = "sooty",
 #' @export
 #'
 #' @examples
-#' available_datasets()
+#' try(available_datasets())
 available_datasets <- function() {
   sort(unique(sooty_files()$Dataset))
 }

--- a/R/objects.R
+++ b/R/objects.R
@@ -1,7 +1,13 @@
 .read_parquet <- function(curated = TRUE) {
   sourcefile <- "https://projects.pawsey.org.au/idea-objects/idea-objects.parquet"
   if (curated) sourcefile <- "https://projects.pawsey.org.au/idea-objects/idea-curated-objects.parquet"
-  tibble::as_tibble(arrow::read_parquet(sourcefile))
+  tryCatch(
+    tibble::as_tibble(arrow::read_parquet(sourcefile)),
+    error = function(e) {
+      stop(sprintf("Could not connect to\n  '%s'\n  Try again later when the server is available.\n  Original error: %s",
+                   sourcefile, conditionMessage(e)), call. = FALSE)
+    }
+  )
 }
 #' @importFrom arrow  read_parquet
 .objects <- function() {
@@ -51,7 +57,7 @@
 #'   sooty_files(FALSE)
 #' }
 #'
-#' sooty_files()
+#' try(sooty_files())
 sooty_files <- function(curated = TRUE) {
   if (curated) {
     return(.curated_files())

--- a/man/available_datasets.Rd
+++ b/man/available_datasets.Rd
@@ -14,5 +14,5 @@ In \code{sooty_files()} the data source files are grouped by \code{Dataset}, thi
 list of unique datasets, values that can be used in \verb{datasource(<name>)}.
 }
 \examples{
-available_datasets()
+try(available_datasets())
 }

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -39,6 +39,6 @@ if (interactive()) {
  available_datasets()
 }
 ## set to one of those
-ds  <- datasource("ghrsst-tif")
+try(ds  <- datasource("ghrsst-tif"))
 ## access the 'ds@source' slot, files with 'date','source' (GDAL-readable)
 }

--- a/man/sooty_files.Rd
+++ b/man/sooty_files.Rd
@@ -33,5 +33,5 @@ if (interactive()) {
   sooty_files(FALSE)
 }
 
-sooty_files()
+try(sooty_files())
 }


### PR DESCRIPTION
## Summary
This PR enhances error handling when connecting to remote data sources and updates documentation examples to handle potential connection failures gracefully.

## Key Changes
- **Enhanced error handling in `.read_parquet()`**: Wrapped the parquet file reading operation in a `tryCatch()` block to catch connection errors and provide a user-friendly error message that indicates the server may be temporarily unavailable, while preserving the original error details for debugging.

- **Updated documentation examples**: Wrapped all example calls to functions that depend on remote data sources (`sooty_files()`, `available_datasets()`, and `datasource()`) with `try()` to prevent example execution failures when the remote server is unavailable. This ensures documentation examples don't fail during package checks.

## Implementation Details
- The error message now clearly indicates which URL failed to connect and suggests retrying when the server is available
- Original error messages are preserved and included in the output for troubleshooting
- The `call. = FALSE` parameter prevents R from including the function call in the error message, keeping the output cleaner
- Documentation examples are now more robust and won't cause `R CMD check` failures due to network unavailability

https://claude.ai/code/session_01PURNTXU1dgu9dgcWZ4wFwP